### PR TITLE
Add subscription endpoint to 'Identity Details' view

### DIFF
--- a/CRM/Aws/Ses/Page/IdentityDetails.php
+++ b/CRM/Aws/Ses/Page/IdentityDetails.php
@@ -22,6 +22,20 @@ class CRM_Aws_Ses_Page_IdentityDetails extends CRM_Core_Page {
 
     unset($identity['id'], $identity['Identity'], $identity['Type']);
 
+    if (isset($identity['Topics'])) {
+      foreach ($identity['Topics'] as $topicKey => $topicValue) {
+        if (!isset($identity['Subscriptions'])) {
+          $identity['Subscriptions'] = [];
+        }
+        if (isset($topicValue['Subscriptions'])) {
+          foreach ($topicValue['Subscriptions'] as $subscriptionKey => $subscriptionValue) {
+            $identity['Subscriptions'][] = $subscriptionValue['Endpoint'];
+          }
+        }
+        $identity['Subscriptions'] = implode(', ', $identity['Subscriptions']);
+      }
+      unset($identity['Topics']);
+    }
     $this->assign(
       'identity',
       $identity


### PR DESCRIPTION
This adds the list of subscription endpoints to the Identity Details form:

`
Subscriptions | https://www.example.org/civicrm?page=CiviCRM&q=civicrm%2Faws-sns%2Fwebhook
`